### PR TITLE
Sanitize JSON in server side rendering

### DIFF
--- a/app/views/pageflow/react/page.html.erb
+++ b/app/views/pageflow/react/page.html.erb
@@ -1,7 +1,7 @@
 <% if page.template.present? %>
   <% concat React::ServerRendering.render(
-     Pageflow.config.page_types.find_by_name!(page.template).component_name, MultiJson.dump(
+     Pageflow.config.page_types.find_by_name!(page.template).component_name, sanitize_json(MultiJson.dump(
      resolverSeed: @_pageflow_react_entry_seed ||= entry_seed(@entry),
      pageId: page.perma_id
-   ), true) %>
+   )), true) %>
 <% end %>


### PR DESCRIPTION
Utf-8 characters like \u2029 are permitted in JSON but lead to syntax
errors in JS. Prevent funny configuration inputs from breaking server
side rendering.
