### PR TITLE
Ensure all page hooks are triggered on page deactivate

### DIFF
--- a/js/src/create_page_component.jsx
+++ b/js/src/create_page_component.jsx
@@ -19,6 +19,10 @@ export default function(Component) {
         },
 
         deactivating: () => {
+          trigger('pageWillDeactivate');
+        },
+
+        deactivated: () => {
           trigger('pageDidDeactivate');
         },
 


### PR DESCRIPTION
Before `pageWillDeactivate` was missing and `pageDidDeactivate` fired
early.
