### PR TITLE
Higher order mutate

### DIFF
--- a/js/src/mutate.js
+++ b/js/src/mutate.js
@@ -1,17 +1,10 @@
-import UpdatePageMutation from './mutations/update_page_mutation';
-import UpdatePageLinkMutation from './mutations/update_page_link_mutation';
-
-var mutations = {
-  updatePage: UpdatePageMutation,
-  updatePageLink: UpdatePageLinkMutation
-};
+import MutationResolver from 'resolvers/MutationResolver';
 
 export default function(mutationName, props) {
-  var mutation = mutations[mutationName];
-
-  if (!mutation) {
-    throw `Unknown mutation ${mutationName}`;
-  }
-
-  return new mutation(props).perform();
-};
+  return function(callback) {
+    return new MutationResolver({
+      name: mutationName,
+      props
+    }, callback);
+  };
+}

--- a/js/src/mutations/update_page_link_mutation.js
+++ b/js/src/mutations/update_page_link_mutation.js
@@ -3,22 +3,22 @@ import Mutation from './mutation';
 import pageflow from 'pageflow';
 
 export default class extends Mutation {
-  perform() {
-    this._getPageLink().set(this.props.attributes);
+  perform(options) {
+    this._getPageLink(options.id).set(options.attributes);
   }
 
-  _getPageLink() {
-    var pageLink = this._getPage().pageLinks().get(this.props.id);
+  _getPageLink(pageLinkId) {
+    var pageLink = this._getPage(pageLinkId).pageLinks().get(pageLinkId);
 
     if (!pageLink) {
-      throw new Error(`Could not find page link with id ${this.props.pageLinkId}.`);
+      throw new Error(`Could not find page link with id ${pageLinkId}.`);
     }
 
     return pageLink;
   }
 
-  _getPage() {
-    var [pageId] = this.props.id.split(':');
+  _getPage(pageLinkId) {
+    var [pageId] = pageLinkId.split(':');
     var page = pageflow.pages.getByPermaId(pageId);
 
     if (!page) {

--- a/js/src/mutations/update_page_mutation.js
+++ b/js/src/mutations/update_page_mutation.js
@@ -3,15 +3,15 @@ import Mutation from './mutation';
 import pageflow from 'pageflow';
 
 export default class extends Mutation {
-  perform() {
-    this._getPage().configuration.set(this.props.attributes);
+  perform(options) {
+    this._getPage(options.pageId).configuration.set(options.attributes);
   }
 
-  _getPage() {
-    var page = pageflow.pages.get(this.props.pageId);
+  _getPage(pageId) {
+    var page = pageflow.pages.get(pageId);
 
     if (!page) {
-      throw new Error(`Could not find page with id ${this.props.pageId}.`);
+      throw new Error(`Could not find page with id ${pageId}.`);
     }
 
     return page;

--- a/js/src/resolvers/MutationResolver.js
+++ b/js/src/resolvers/MutationResolver.js
@@ -1,0 +1,29 @@
+import Resolver from './resolver';
+
+import UpdatePageMutation from 'mutations/update_page_mutation';
+import UpdatePageLinkMutation from 'mutations/update_page_link_mutation';
+import SettingMutation from 'mutations/SettingMutation';
+
+const mutations = {
+  updatePage: UpdatePageMutation,
+  updatePageLink: UpdatePageLinkMutation,
+  setting: SettingMutation
+};
+
+export default class MutationResolver extends Resolver {
+  constructor(options, callback) {
+    super(callback);
+
+    this.mutation = mutations[options.name];
+    this.props = options.props;
+
+    if (!this.mutation) {
+      throw `Unknown mutation ${options.name}.`;
+    }
+  }
+
+  get() {
+    const instance = new this.mutation(this.props);
+    return (...args) => instance.perform(...args);
+  }
+}


### PR DESCRIPTION
`mutate` now returns a function that performs the mutation instead of performing the mutation directly. This enables usage of `mutate` along `resolve` in a `createContainer` call.
