### PR TITLE
Update to Babel 6

### DIFF
--- a/js/.babelrc
+++ b/js/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["es2015", "react"],
+  "plugins": ["transform-object-rest-spread"]
+}

--- a/js/karma.conf.js
+++ b/js/karma.conf.js
@@ -48,7 +48,7 @@ module.exports = function (config) {
           {
             test: /\.jsx?$/,
             exclude: /node_modules/,
-            loader: 'babel-loader?stage=0&optional[]=runtime'
+            loaders: ['babel-loader']
           },
           {
             test: require.resolve('react'),

--- a/js/package.json
+++ b/js/package.json
@@ -17,8 +17,11 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "babel-core": "^5.8.22",
-    "babel-loader": "^5.3.2",
+    "babel-core": "^6.14.0",
+    "babel-loader": "^6.2.5",
+    "babel-plugin-transform-object-rest-spread": "^6.8.0",
+    "babel-preset-es2015": "^6.14.0",
+    "babel-preset-react": "^6.11.1",
     "backbone": "^1.2.2",
     "chai": "^3.2.0",
     "chai-enzyme": "^0.5.0",
@@ -46,12 +49,11 @@
     "sinon": "git://github.com/cjohansen/Sinon.JS#b672042043517b9f84e14ed0fb8265126168778a",
     "sinon-chai": "^2.8.0",
     "underscore": "^1.8.3",
-    "webpack": "^1.11.0",
-    "webpack-dev-server": "^1.14.1"
+    "webpack": "^1.13.2",
+    "webpack-dev-server": "^1.16.1"
   },
   "dependencies": {
     "babel-polyfill": "^6.2.0",
-    "babel-runtime": "^5.8.20",
     "classnames": "^2.1.3",
     "react": "^0.14.3",
     "react-dom": "^0.14.3",

--- a/js/spec/support/chai.js
+++ b/js/spec/support/chai.js
@@ -5,4 +5,4 @@ import sinonChai from 'sinon-chai';
 chai.use(chaiEnzyme());
 chai.use(sinonChai);
 
-export default chai;
+export const expect = chai.expect;

--- a/js/src/components/BackgroundImage.jsx
+++ b/js/src/components/BackgroundImage.jsx
@@ -5,24 +5,6 @@ import classNames from 'classnames';
  * Display an element with a background image.
  */
 export default class BackgroundImage extends React.Component {
-  static propTypes = {
-    /** The id of the image file to display */
-    imageFileId: React.PropTypes.number,
-
-    /** Background position */
-    position: React.PropTypes.arrayOf(React.PropTypes.number),
-
-    /** Additional CSS classes. */
-    className: React.PropTypes.string,
-
-    /** Used to lazy load images. */
-    loaded: React.PropTypes.bool
-  }
-
-  static defaultProps = {
-    position: [50, 50]
-  }
-
   render() {
     return (
       <div className={this.cssClass()} style={this.style()}>
@@ -57,4 +39,22 @@ export default class BackgroundImage extends React.Component {
 
     return coordinate;
   }
+}
+
+BackgroundImage.propTypes = {
+  /** The id of the image file to display */
+  imageFileId: React.PropTypes.number,
+
+  /** Background position */
+  position: React.PropTypes.arrayOf(React.PropTypes.number),
+
+  /** Additional CSS classes. */
+  className: React.PropTypes.string,
+
+  /** Used to lazy load images. */
+  loaded: React.PropTypes.bool
+};
+
+BackgroundImage.defaultProps = {
+  position: [50, 50]
 };

--- a/js/src/components/PageScroller.jsx
+++ b/js/src/components/PageScroller.jsx
@@ -4,10 +4,6 @@ import Scroller from './Scroller';
 import withPageLifecycle from '../withPageLifecycle.jsx';
 
 export default class PageScroller extends React.Component {
-  static childContextTypes = {
-    pageScroller: React.PropTypes.object
-  }
-
   getChildContext() {
     this._pageScroller = this._pageScroller || {
       disable: () => {
@@ -34,16 +30,20 @@ export default class PageScroller extends React.Component {
   }
 
   pageWillActivate(options) {
-    this.refs.scroller.resetPosition({position: options.position})
+    this.refs.scroller.resetPosition({position: options.position});
   }
 
   pageDidActivate() {
-    this.refs.scroller.enable()
+    this.refs.scroller.enable();
   }
 
   pageWillDeactivate() {
-    this.refs.scroller.disable()
+    this.refs.scroller.disable();
   }
+}
+
+PageScroller.childContextTypes = {
+  pageScroller: React.PropTypes.object
 };
 
 export default withPageLifecycle(PageScroller);

--- a/js/src/components/PageScroller.jsx
+++ b/js/src/components/PageScroller.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import Scroller from './Scroller';
 import withPageLifecycle from '../withPageLifecycle.jsx';
 
-export default class PageScroller extends React.Component {
+class PageScroller extends React.Component {
   getChildContext() {
     this._pageScroller = this._pageScroller || {
       disable: () => {

--- a/js/src/components/PageText.jsx
+++ b/js/src/components/PageText.jsx
@@ -12,6 +12,4 @@ export default class PageText extends Component {
   text() {
     return {__html: this.props.page.text};
   }
-};
-
-export default PageText;
+}

--- a/js/src/createContainer.jsx
+++ b/js/src/createContainer.jsx
@@ -13,11 +13,7 @@ export default function(Component, options) {
     };
   }
 
-  return class extends React.Component {
-    static contextTypes = {
-      resolverSeed: React.PropTypes.object
-    }
-
+  class Container extends React.Component {
     constructor(props, context) {
       super(props, context);
 
@@ -48,6 +44,11 @@ export default function(Component, options) {
     render() {
       return (<Component {...this.state} />);
     }
+  }
+
+  Container.contextTypes = {
+    resolverSeed: React.PropTypes.object
   };
 
-};
+  return Container;
+}

--- a/js/src/createResolverRoot.jsx
+++ b/js/src/createResolverRoot.jsx
@@ -1,11 +1,7 @@
 import React from 'react';
 
 export default function(Component) {
-  return class extends React.Component {
-    static childContextTypes = {
-      resolverSeed: React.PropTypes.object
-    }
-
+  class ResolverRoot extends React.Component {
     getChildContext() {
       return {
         resolverSeed: this.props.resolverSeed || {}
@@ -17,5 +13,11 @@ export default function(Component) {
         <Component {...this.props} />
       );
     }
+  }
+
+  ResolverRoot.childContextTypes = {
+    resolverSeed: React.PropTypes.object
   };
-};
+
+  return ResolverRoot;
+}

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -1,3 +1,5 @@
+/*global module*/
+
 import createPage from './createPage';
 import createWidget from './createWidget';
 import createContainer from './createContainer';
@@ -30,7 +32,10 @@ import SvgIcon from './components/icons/Container';
 
 import Draggable from 'react-draggable';
 
-export default {
+// `export default` does not play well with Webpack's `libraryTarget:
+// 'assign'` at the moment. See
+// https://github.com/webpack/webpack/issues/706
+module.exports = {
   /** @api public */
   createContainer,
 

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -19,7 +19,7 @@ module.exports = {
       {
         test: /\.jsx?$/,
         exclude: /node_modules/,
-        loaders: ['babel-loader?stage=0'],
+        loaders: ['babel-loader'],
       }
     ],
   },


### PR DESCRIPTION
- Remove static properties, a ES feature which is only Stage 2 at the moment. 
- Switch to `module.exports` syntax in `index.js`, since rewritten
  Babel export is no longer compatible with Webpack's "libraryTarget
  assign" feature.
- Remove duplicate `export default` calls.
- Export `expect` explicitly in `support/chai`. Exporting the `chai`
  object as default no longer allows destructive `import` calls to
  assign `expect`.
